### PR TITLE
Modified a minor typo

### DIFF
--- a/mtPyEcon/AR1_process.py
+++ b/mtPyEcon/AR1_process.py
@@ -105,5 +105,5 @@ class AR1_process:
                        fmt='%2.3f', newline=' \\\\\n')
         
         # Store the result as the instance's attributes
-        self.__dict__['{0}_gird'.format(self.varname)] = x_grid
+        self.__dict__['{0}_grid'.format(self.varname)] = x_grid
         self.trans_mat, self.step_size = Pi_N, h


### PR DESCRIPTION
Tanaka-san,

Hajimemashite. I'm Mikami. I'm PhD student in UVA.
Your Python programs are very well-organized. I'm using them as good references to learn Python.

Btw, I found a minor typo in Rouwenhorst discretization. When saving the grid, the attribute is labeled "x_gird" not "x_grid." I modified it on my fork. If you don't mind, please merge my fork to your original.